### PR TITLE
Fix cors and limit api

### DIFF
--- a/demo/server.json
+++ b/demo/server.json
@@ -2,5 +2,10 @@
 	"host": "127.0.0.1",
 	"port": 8440,
 	"assetsPath": "demo/assets",
-	"assetsExt": "png"
+	"assetsExt": "png",
+	"extra": {
+		"whitelistedOrigin": "*",
+		"maxTitleLength": 256,
+		"maxDescriptionLength": 1024
+	}
 }

--- a/demo/server.json
+++ b/demo/server.json
@@ -1,13 +1,12 @@
 {
-	"assetsConfig": {
-		"assetsPath": "demo/assets",
-		"assetsExt": "png"
+	"assets": {
+		"path": "demo/assets",
+		"ext": "png"
 	},
-	"serverConfig": {
+	"server": {
 		"host": "127.0.0.1",
 		"port": 8440,
 		"whitelistedOrigin": "*",
-		"maxTitleLength": 256,
-		"maxDescriptionLength": 1024
+		"maxPayloadSize": 1280
 	}
 }

--- a/demo/server.json
+++ b/demo/server.json
@@ -1,9 +1,11 @@
 {
-	"host": "127.0.0.1",
-	"port": 8440,
-	"assetsPath": "demo/assets",
-	"assetsExt": "png",
-	"extra": {
+	"assetsConfig": {
+		"assetsPath": "demo/assets",
+		"assetsExt": "png"
+	},
+	"serverConfig": {
+		"host": "127.0.0.1",
+		"port": 8440,
 		"whitelistedOrigin": "*",
 		"maxTitleLength": 256,
 		"maxDescriptionLength": 1024

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 		}
 	}()
 
-	serv := nftserv.New(nft.NewMemory(), ast)
+	serv := nftserv.New(nft.NewMemory(), ast, servCfg.Extra)
 	// inject new balances from operator
 	op.OnNewBalance(serv.UpdateBalance)
 	addr := servCfg.Addr()

--- a/main.go
+++ b/main.go
@@ -38,11 +38,11 @@ func main() {
 	}
 	log.Info("NFT Server config loaded")
 
-	ast, err := asset.NewFileStorage(servCfg.AssetsConfig.AssetsPath)
+	ast, err := asset.NewFileStorage(servCfg.Assets.Path)
 	if err != nil {
 		log.Fatalf("Main: error opening assets storage: %v", err)
 	}
-	ast.SetExtension(servCfg.AssetsConfig.AssetsExt)
+	ast.SetExtension(servCfg.Assets.Ext)
 	log.Info("Assets storage opened")
 
 	op := operator.SetupWithPrototypeEnclave(cfg, nil)
@@ -52,10 +52,10 @@ func main() {
 		}
 	}()
 
-	serv := nftserv.New(nft.NewMemory(), ast, servCfg.ServerConfig)
+	serv := nftserv.New(nft.NewMemory(), ast, servCfg.Server)
 	// inject new balances from operator
 	op.OnNewBalance(serv.UpdateBalance)
-	addr := servCfg.ServerConfig.Addr()
+	addr := servCfg.Server.Addr()
 	if err := serv.Serve(); err != nil {
 		log.Errorf("Main: NFTServer.ListenAndServe(%s) stopped with error %v", addr, err)
 	}

--- a/nft/memory_test.go
+++ b/nft/memory_test.go
@@ -36,6 +36,6 @@ func TestNFTMemory(t *testing.T) {
 	m.Upsert(tkn)
 	get, err = m.Get(tkn.Token, tkn.ID)
 	assert.NoError(err)
-	assert.NotEqual(get, tkn)
+	assert.Equal(get, tkn)
 	assert.Equal(m.TotalSize(), 1)
 }

--- a/nft/memory_test.go
+++ b/nft/memory_test.go
@@ -36,6 +36,6 @@ func TestNFTMemory(t *testing.T) {
 	m.Upsert(tkn)
 	get, err = m.Get(tkn.Token, tkn.ID)
 	assert.NoError(err)
-	assert.Equal(get, tkn)
+	assert.NotEqual(get, tkn)
 	assert.Equal(m.TotalSize(), 1)
 }

--- a/nft/nft.go
+++ b/nft/nft.go
@@ -83,7 +83,7 @@ func (t *NFT) Update(source NFT) {
 	} else if t.ID.Cmp(source.ID) != 0 {
 		panic("NFT.Update: ID mismatch")
 	}
-	if source.Owner == eth.Zero {
+	if source.Owner != eth.Zero {
 		t.Owner = source.Owner
 	}
 	if source.AssetID != 0 {

--- a/nftserv/config.go
+++ b/nftserv/config.go
@@ -12,23 +12,22 @@ const defaultWhitelistedOrigin = "*"
 
 type (
 	Config struct {
-		AssetsConfig AssetsConfig `json:"assetsConfig"`
-		ServerConfig ServerConfig `json:"serverConfig"`
+		Assets AssetsConfig `json:"assets"`
+		Server ServerConfig `json:"server"`
 	}
 
 	AssetsConfig struct {
-		AssetsPath string `json:"assetsPath"`
-		AssetsExt  string `json:"assetsExt"`
+		Path string `json:"path"`
+		Ext  string `json:"ext"`
 	}
 
 	ServerConfig struct {
-		Host                 string `json:"host"`
-		Port                 uint16 `json:"port"`
-		CertFile             string `json:"certFile"`
-		KeyFile              string `json:"keyFile"`
-		WhitelistedOrigin    string `json:"whitelistedOrigin"`
-		MaxTitleLength       int    `json:"maxTitleLength"`
-		MaxDescriptionLength int    `json:"maxDescriptionLength"`
+		Host              string `json:"host"`
+		Port              uint16 `json:"port"`
+		CertFile          string `json:"certFile"`
+		KeyFile           string `json:"keyFile"`
+		WhitelistedOrigin string `json:"whitelistedOrigin"`
+		MaxPayloadSize    int    `json:"maxPayloadSize"`
 	}
 )
 
@@ -43,8 +42,8 @@ func ReadConfig(filePath string) (*Config, error) {
 		return nil, fmt.Errorf("decoding server nerd-op config: %w", err)
 	}
 
-	if c.ServerConfig.WhitelistedOrigin == "" {
-		c.ServerConfig.WhitelistedOrigin = defaultWhitelistedOrigin
+	if c.Server.WhitelistedOrigin == "" {
+		c.Server.WhitelistedOrigin = defaultWhitelistedOrigin
 	}
 
 	return c, nil

--- a/nftserv/config.go
+++ b/nftserv/config.go
@@ -9,12 +9,19 @@ import (
 )
 
 type Config struct {
-	Host       string `json:"host"`
-	Port       uint16 `json:"port"`
-	AssetsPath string `json:"assetsPath"`
-	AssetsExt  string `json:"assetsExt"`
-	CertFile   string `json:"certFile"`
-	KeyFile    string `json:"keyFile"`
+	Host       string       `json:"host"`
+	Port       uint16       `json:"port"`
+	AssetsPath string       `json:"assetsPath"`
+	AssetsExt  string       `json:"assetsExt"`
+	CertFile   string       `json:"certFile"`
+	KeyFile    string       `json:"keyFile"`
+	Extra      ServerExtras `json:"extra"`
+}
+
+type ServerExtras struct {
+	WhitelistedOrigin    *string `json:"whitelistedOrigin"`
+	MaxTitleLength       *int    `json:"maxTitleLength"`
+	MaxDescriptionLength *int    `json:"maxDescriptionLength"`
 }
 
 func ReadConfig(filePath string) (*Config, error) {

--- a/nftserv/server.go
+++ b/nftserv/server.go
@@ -146,19 +146,13 @@ func (s *Server) handleNFTRequest(w http.ResponseWriter, r *http.Request, handle
 }
 
 func (s *Server) handlePUTnft(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.MaxPayloadSize > 0 && r.ContentLength >= int64(s.cfg.MaxPayloadSize) {
+		http.Error(w, "NFT title and description too large", http.StatusRequestEntityTooLarge)
+	}
+
 	var newtkn nft.NFT
 	if err := json.NewDecoder(r.Body).Decode(&newtkn); err != nil {
 		http.Error(w, "Error decoding token from payload: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	if len(newtkn.Title) > s.cfg.MaxTitleLength {
-		httpError(w, "NFT title too long", http.StatusRequestEntityTooLarge)
-		return
-	}
-
-	if len(newtkn.Desc) > s.cfg.MaxDescriptionLength {
-		httpError(w, "NFT description too long", http.StatusRequestEntityTooLarge)
 		return
 	}
 

--- a/nftserv/server_test.go
+++ b/nftserv/server_test.go
@@ -34,8 +34,9 @@ import (
 )
 
 const (
-	addr = "127.0.0.1:13443"
-	ext  = "pc"
+	addr              = "127.0.0.1:13443"
+	ext               = "pc"
+	whitelistedOrigin = "*"
 )
 
 func TestServer(t *testing.T) {
@@ -45,7 +46,7 @@ func TestServer(t *testing.T) {
 		nfts       = nft.NewMemory()
 		assetsDir  = createTmpAssetsDir(t, ext, 0, 1, 420)
 		assets, _  = asset.NewFileStorage(assetsDir)
-		srv        = nftserv.New(nfts, assets)
+		srv        = nftserv.New(nfts, assets, nftserv.ServerExtras{})
 		owner, acc = randomAccount(rng, 5)
 		tv         = acc.Values.OrderedValues()[0]
 		ids        = value.MustAsBigInts(tv.Value)

--- a/nftserv/server_test.go
+++ b/nftserv/server_test.go
@@ -34,9 +34,8 @@ import (
 )
 
 const (
-	addr              = "127.0.0.1:13443"
-	ext               = "pc"
-	whitelistedOrigin = "*"
+	addr = "127.0.0.1:13443"
+	ext  = "pc"
 )
 
 func TestServer(t *testing.T) {
@@ -135,6 +134,17 @@ func TestServer(t *testing.T) {
 	require.NoError(err)
 	requireStatus(t, resp, http.StatusOK)
 	expectAsset(tkn.Token, tkn.ID, 420)
+
+	tkn.Title = strings.Repeat("pay_respect", 25)
+	resp, err = putAsJSON(url("nft", tkn.Token.String(), tkn.ID), tkn)
+	require.NoError(err)
+	requireStatus(t, resp, http.StatusRequestEntityTooLarge)
+
+	tkn.Title = "Valid Title"
+	tkn.Desc = strings.Repeat("fubar", 210)
+	resp, err = putAsJSON(url("nft", tkn.Token.String(), tkn.ID), tkn)
+	require.NoError(err)
+	requireStatus(t, resp, http.StatusRequestEntityTooLarge)
 }
 
 func requireStatus(t testing.TB, resp *http.Response, code int) {

--- a/nftserv/server_test.go
+++ b/nftserv/server_test.go
@@ -47,8 +47,9 @@ func TestServer(t *testing.T) {
 		assetsDir           = createTmpAssetsDir(t, ext, 0, 1, 420)
 		assets, _           = asset.NewFileStorage(assetsDir)
 		defaultServerConfig = nftserv.ServerConfig{
-			Host: host,
-			Port: port,
+			Host:           host,
+			Port:           port,
+			MaxPayloadSize: 1024,
 		}
 		srv        = nftserv.New(nfts, assets, defaultServerConfig)
 		owner, acc = randomAccount(rng, 5)
@@ -141,11 +142,6 @@ func TestServer(t *testing.T) {
 	expectAsset(tkn.Token, tkn.ID, 420)
 
 	tkn.Title = strings.Repeat("pay_respect", 25)
-	resp, err = putAsJSON(url("nft", tkn.Token.String(), tkn.ID), tkn)
-	require.NoError(err)
-	requireStatus(t, resp, http.StatusRequestEntityTooLarge)
-
-	tkn.Title = "Valid Title"
 	tkn.Desc = strings.Repeat("fubar", 210)
 	resp, err = putAsJSON(url("nft", tkn.Token.String(), tkn.ID), tkn)
 	require.NoError(err)


### PR DESCRIPTION
The behavior for Cross-Origin-Resource-Sharing (CORS) can now be configured in the `server_config.json`.

Same thing for the NFT title and description size.

I also changed the `nft/memory_test.go`, tell me if I misunderstood something there.

Regarding rate-limiting: This should be possible via some nginx configuration. It is also possible to do this in Go, but this is a little bit more involved, unless we are ready to use an external package implementing a token-bucket algorithm. I think `golang.org/x/time/rate` is a good candidate for this.